### PR TITLE
Add Create User API endpoint

### DIFF
--- a/users/src/create_user/main.py
+++ b/users/src/create_user/main.py
@@ -1,0 +1,78 @@
+import json
+import os
+import boto3
+from aws_lambda_powertools.tracing import Tracer
+from aws_lambda_powertools.logging.logger import Logger
+
+logger = Logger()
+tracer = Tracer()
+
+cognito = boto3.client("cognito-idp")
+user_pool_id = os.environ['USER_POOL_ID']
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def handler(event, _):
+    try:
+        body = json.loads(event['body'])
+        email = body['email']
+        user_type = body['userType']
+        password = body['password']
+
+        # Validate userType
+        if user_type not in ['host', 'guest']:
+            return {
+                'statusCode': 400,
+                'body': json.dumps({
+                    'message': 'Invalid user type. Must be either "host" or "guest".',
+                    'code': 400,
+                    'details': f'Provided userType: {user_type}'
+                })
+            }
+
+        # Create user in Cognito
+        response = cognito.admin_create_user(
+            UserPoolId=user_pool_id,
+            Username=email,
+            UserAttributes=[
+                {'Name': 'email', 'Value': email},
+                {'Name': 'email_verified', 'Value': 'true'}
+            ],
+            MessageAction='SUPPRESS'
+        )
+
+        user_id = response['User']['Username']
+
+        # Set user password
+        cognito.admin_set_user_password(
+            UserPoolId=user_pool_id,
+            Username=user_id,
+            Password=password,
+            Permanent=True
+        )
+        
+        # Add user to the specified group
+        cognito.admin_add_user_to_group(
+            UserPoolId=user_pool_id,
+            Username=user_id,
+            GroupName=user_type
+        )
+        
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                'userId': user_id,
+                'email': email,
+                'userType': user_type
+            })
+        }
+    except Exception as error:
+        logger.error(error)
+        return {
+            'statusCode': 500,
+            'body': json.dumps({
+                'message': 'Internal server error',
+                'code': 500,
+                'details': str(error)
+            })
+        }

--- a/users/src/sign_up/main.py
+++ b/users/src/sign_up/main.py
@@ -1,8 +1,3 @@
-"""
-SignUpFunction
-"""
-
-
 import datetime
 import json
 import os
@@ -10,15 +5,15 @@ from aws_lambda_powertools.tracing import Tracer
 from aws_lambda_powertools.logging.logger import Logger
 import boto3
 
-
 ENVIRONMENT = os.environ["ENVIRONMENT"]
 EVENT_BUS_NAME = os.environ["EVENT_BUS_NAME"]
 
+eventbridge = boto3.client("events")
+dynamodb = boto3.resource('dynamodb')
+logger = Logger()
+tracer = Tracer()
 
-eventbridge = boto3.client("events") # pylint: disable=invalid-name
-logger = Logger() # pylint: disable=invalid-name
-tracer = Tracer() # pylint: disable=invalid-name
-
+users_table = dynamodb.Table(os.environ['TABLE_NAME'])
 
 @tracer.capture_method
 def process_request(input_: dict) -> dict:
@@ -40,7 +35,6 @@ def process_request(input_: dict) -> dict:
 
     return output
 
-
 @tracer.capture_method
 def send_event(event: dict):
     """
@@ -49,6 +43,64 @@ def send_event(event: dict):
 
     eventbridge.put_events(Entries=[event])
 
+@tracer.capture_method
+def save_user_to_dynamodb(user_id: str, email: str, user_role: str):
+    """
+    Save user information to DynamoDB
+    """
+    item = {
+        'userId': user_id,
+        'email': email,
+        'profile': {
+            'avatarPictureAddress': '',
+            'about': '',
+            'whereHaveBeen': [],
+            'hobby': [],
+            'languages': [],
+            'favoriteSong': '',
+            'location': '',
+            'joinDate': datetime.datetime.now().date().isoformat(),
+            'school': '',
+            'work': '',
+            'birthDecade': '',
+            'funFactUselessSkill': ''
+        },
+        'personalInformation': {
+            'legalName': '',
+            'preferredFirstName': '',
+            'phoneNumber': '',
+            'address': '',
+            'emergencyContact': {
+                'name': '',
+                'phone': '',
+                'relationship': ''
+            },
+            'governmentID': ''
+        },
+        'financeInformation': {
+            'paymentMethod': {
+                'cardType': '',
+                'lastFourDigits': '',
+                'expiryDate': ''
+            },
+            'payoutInformation': {
+                'bankName': '',
+                'accountNumber': '',
+                'routingNumber': ''
+            },
+            'creditsCoupons': {
+                'totalCredits': 0,
+                'activeCoupons': []
+            },
+            'taxInformation': {
+                'taxID': '',
+                'taxStatus': ''
+            },
+            'transactionHistory': []
+        },
+        'userType': user_role
+    }
+    users_table.put_item(Item=item)
 
 @logger.inject_lambda_context
 @tracer.capture_lambda_handler
@@ -57,22 +109,17 @@ def handler(event, _):
     Lambda handler
     """
 
-    # Input event:
-    # https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-pools-lambda-trigger-event-parameter-shared
     logger.debug({
         "message": "Input event",
         "event": event
     })
 
-    # Never confirm users
     event["response"] = {
         "autoConfirmUser": False,
         "autoVerifyPhone": False,
         "autoVerifyEmail": False
     }
 
-    # Only care about the ConfirmSignUp action
-    # At the moment, the only other PostConfirmation event is 'PostConfirmation_ConfirmForgotPassword'
     if event["triggerSource"] not in ["PreSignUp_SignUp", "PreSignUp_AdminCreateUser"]:
         logger.warning({
             "message": "invalid triggerSource",
@@ -80,11 +127,14 @@ def handler(event, _):
         })
         return event
 
-    # Prepare the event
-    eb_event = process_request(event)
+    username = event["userName"]
+    user_attributes = event["request"]["userAttributes"]
+    email = user_attributes.get("email", "")
+    user_role = event["request"]["clientMetadata"].get("role", "guest")
 
-    # Send the event to EventBridge
+    save_user_to_dynamodb(username, email, user_role)
+
+    eb_event = process_request(event)
     send_event(eb_event)
 
-    # Always return the event at the end
     return event

--- a/users/src/sign_up/requirements.txt
+++ b/users/src/sign_up/requirements.txt
@@ -1,2 +1,3 @@
 aws-lambda-powertools==1.16.1
 boto3
+wrapt>=1.11,<1.14


### PR DESCRIPTION
- Implemented a new POST API endpoint `/users/create` to create a new user.
- Added a Lambda function `CreateUserFunction` to handle the request and create users in Cognito and DynamoDB.