### PR TITLE
Add Delete Listing API endpoint

### DIFF
--- a/listings/resourse/openapi.yaml
+++ b/listings/resourse/openapi.yaml
@@ -229,3 +229,57 @@ paths:
                     message: "Internal server error"
                     code: 500
                     details: "An unexpected error occurred while processing the request."
+
+  /listings/delete/{listingId}:
+    delete:
+      summary: Delete a listing by listing ID.
+      operationId: deleteListing
+      security:
+        - CognitoAuth: []
+      parameters:
+        - name: listingId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              examples:
+                success:
+                  summary: Successful deletion
+                  value:
+                    message: "Listing successfully deleted."
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                badRequest:
+                  summary: Invalid listing ID
+                  value:
+                    message: "Invalid listing ID"
+                    code: 400
+                    details: "The listing ID provided is not valid."
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: Internal Server Error Example
+                  value:
+                    message: "Internal server error"
+                    code: 500
+                    details: "An unexpected error occurred while processing the request."

--- a/listings/src/delete_listing/main.py
+++ b/listings/src/delete_listing/main.py
@@ -1,0 +1,61 @@
+import json
+import os
+import boto3
+from boto3.dynamodb.conditions import Key
+from aws_lambda_powertools.logging import Logger
+from aws_lambda_powertools.tracing import Tracer
+from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
+from aws_lambda_powertools.utilities.data_classes.api_gateway_proxy import Response
+
+logger = Logger()
+tracer = Tracer()
+
+dynamodb = boto3.resource('dynamodb')
+cognito = boto3.client('cognito-idp')
+table = dynamodb.Table(os.environ['TABLE_NAME'])
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def handler(event, context):
+    token = event['headers'].get('Authorization')
+    listing_id = event['pathParameters']['listingId']
+
+    # Validate JWT token and get user information
+    try:
+        user_info = cognito.get_user(AccessToken=token)
+        user_sub = next(attr['Value'] for attr in user_info['UserAttributes'] if attr['Name'] == 'sub')
+        
+        response = table.get_item(Key={'listingId': listing_id})
+        item = response.get('Item')
+
+        if not item:
+            return Response(
+                status_code=400,
+                body=json.dumps({"message": "Invalid listing ID", "code": 400, "details": "Listing ID provided is not valid."})
+            )
+
+        if item['hostId'] != user_sub:
+            return Response(
+                status_code=403,
+                body=json.dumps({"message": "User is not authorized to delete this listing"})
+            )
+
+        table.delete_item(Key={'listingId': listing_id})
+
+        return Response(
+            status_code=200,
+            body=json.dumps({"message": "Listing successfully deleted"})
+        )
+
+    except cognito.exceptions.NotAuthorizedException as e:
+        logger.error(e)
+        return Response(
+            status_code=401,
+            body=json.dumps({"message": "Unauthorized"})
+        )
+    except Exception as e:
+        logger.error(e)
+        return Response(
+            status_code=500,
+            body=json.dumps({"message": "Internal server error", "error": str(e)})
+        )

--- a/listings/template.yaml
+++ b/listings/template.yaml
@@ -172,6 +172,38 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${UpdateListingFunction}"
       RetentionInDays: !Ref RetentionInDays
 
+  DeleteListingFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/delete_listing/
+      Handler: main.handler
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:DeleteItem
+                - dynamodb:GetItem
+              Resource: !GetAtt ListingsTable.Arn
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - cognito-idp:AdminGetUser
+              Resource: "*"
+      Events:
+        DeleteListingApi:
+          Type: Api
+          Properties:
+            Path: /listings/delete/{listingId}
+            Method: delete
+            RestApiId: !Ref ApiGateway
+
+  DeleteListingFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${DeleteListingFunction}"
+      RetentionInDays: !Ref RetentionInDays
 
   ApiGateway:
     Type: AWS::Serverless::Api


### PR DESCRIPTION
- Implemented a new DELETE API endpoint `/listings/delete/{listingId}` to delete a listing by listing ID.
- Added a Lambda function `DeleteListingFunction` to handle the request and delete listing data in DynamoDB.
- Added necessary permissions for the Lambda function to interact with DynamoDB and Cognito.
- Implemented JWT token validation to ensure only the host who owns the listing can delete it.