### PR TITLE
feat: Add List Orders API endpoint

### DIFF
--- a/orders/resources/openapi.yaml
+++ b/orders/resources/openapi.yaml
@@ -155,3 +155,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /orders/list:
+    get:
+      summary: List orders by user ID or listing ID.
+      operationId: listOrders
+      security:
+        - CognitoAuth: []
+      parameters:
+        - name: userId
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: listingId
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Order'
+              examples:
+                success:
+                  summary: A successful response
+                  value:
+                    - orderId: "ORDER#123"
+                      userId: "USER#123"
+                      orderType: "Stay"
+                      detailId: "LISTING#456"
+                      startDate: "2023-01-01"
+                      endDate: "2023-01-10"
+                      date: "2023-01-01"
+                      time: "15:00"
+                      total: 1500
+                      additionalFees:
+                        cleaningFee: 100
+                        serviceFee: 50
+                        taxes: 150
+                      hostId: "HOST#123"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                badRequest:
+                  summary: Bad Request Example
+                  value:
+                    message: "Invalid parameters"
+                    code: 400
+                    details: "The provided parameters are invalid."
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: Internal Server Error Example
+                  value:
+                    message: "Internal server error"
+                    code: 500
+                    details: "An unexpected error occurred while processing the request."

--- a/orders/src/list_orders/main.py
+++ b/orders/src/list_orders/main.py
@@ -1,0 +1,72 @@
+import json
+import os
+import boto3
+from boto3.dynamodb.conditions import Key
+from aws_lambda_powertools.logging import Logger
+from aws_lambda_powertools.tracing import Tracer
+from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
+from aws_lambda_powertools.utilities.data_classes.api_gateway_proxy import Response
+
+logger = Logger()
+tracer = Tracer()
+
+dynamodb = boto3.resource('dynamodb')
+cognito = boto3.client('cognito-idp')
+table = dynamodb.Table(os.environ['TABLE_NAME'])
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def handler(event: APIGatewayProxyEvent, context):
+    try:
+        query_params = event.query_string_parameters or {}
+        user_id = query_params.get('userId')
+        listing_id = query_params.get('listingId')
+        token = event.headers.get('Authorization')
+
+        # Decode token to get user information
+        user_info = cognito.get_user(AccessToken=token)
+        user_sub = next(attr['Value'] for attr in user_info['UserAttributes'] if attr['Name'] == 'sub')
+
+        # Ensure the user has access to the orders
+        if user_id and user_id != user_sub:
+            return Response(
+                status_code=403,
+                body=json.dumps({"message": "User is not authorized to access these orders"})
+            )
+
+        if listing_id:
+            response = table.query(
+                IndexName='listingId-index',
+                KeyConditionExpression=Key('listingId').eq(listing_id)
+            )
+            orders = response.get('Items', [])
+            # Ensure the host has access to the orders
+            if orders and orders[0]['hostId'] != user_sub:
+                return Response(
+                    status_code=403,
+                    body=json.dumps({"message": "User is not authorized to access these orders"})
+                )
+        else:
+            response = table.query(
+                IndexName='userId-index',
+                KeyConditionExpression=Key('userId').eq(user_sub)
+            )
+            orders = response.get('Items', [])
+
+        return Response(
+            status_code=200,
+            body=json.dumps(orders)
+        )
+
+    except cognito.exceptions.NotAuthorizedException as e:
+        logger.error(e)
+        return Response(
+            status_code=401,
+            body=json.dumps({"message": "Unauthorized"})
+        )
+    except Exception as e:
+        logger.error(e)
+        return Response(
+            status_code=500,
+            body=json.dumps({"message": "Internal server error", "error": str(e)})
+        )

--- a/orders/template.yaml
+++ b/orders/template.yaml
@@ -131,3 +131,35 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/lambda/${GetOrderFunction}"
       RetentionInDays: !Ref RetentionInDays
+
+  ListOrdersFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/list_orders/
+      Handler: main.handler
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:Query
+              Resource: !GetAtt OrdersTable.Arn
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - cognito-idp:AdminGetUser
+              Resource: "*"
+      Events:
+        ListOrdersApi:
+          Type: Api
+          Properties:
+            Path: /orders/list
+            Method: get
+            RestApiId: !Ref ApiGateway
+
+  ListOrdersFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${ListOrdersFunction}"
+      RetentionInDays: !Ref RetentionInDays


### PR DESCRIPTION
- Implemented a new GET API endpoint `/orders/list` to list orders by user ID or listing ID.
- Defined input validation and error handling to ensure only authorized users (order owner or host) can access the orders.