### PR TITLE
feat: Add Cancel Order API endpoint

### DIFF
--- a/orders/resources/openapi.yaml
+++ b/orders/resources/openapi.yaml
@@ -282,3 +282,57 @@ paths:
                     message: "Internal server error"
                     code: 500
                     details: "An unexpected error occurred while processing the request."
+
+  /orders/cancel/{orderId}:
+    put:
+      summary: Cancel order by order ID.
+      operationId: cancelOrder
+      security:
+        - CognitoAuth: []
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              examples:
+                success:
+                  summary: A successful response
+                  value:
+                    message: "Order cancelled successfully"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                badRequest:
+                  summary: Bad Request Example
+                  value:
+                    message: "Invalid order ID"
+                    code: 400
+                    details: "Order ID provided is not valid."
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: Internal Server Error Example
+                  value:
+                    message: "Internal server error"
+                    code: 500
+                    details: "An unexpected error occurred while processing the request."

--- a/orders/src/cancel_order/main.py
+++ b/orders/src/cancel_order/main.py
@@ -1,0 +1,68 @@
+import json
+import os
+import boto3
+from boto3.dynamodb.conditions import Key
+from aws_lambda_powertools.logging import Logger
+from aws_lambda_powertools.tracing import Tracer
+from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
+from aws_lambda_powertools.utilities.data_classes.api_gateway_proxy import Response
+
+logger = Logger()
+tracer = Tracer()
+
+dynamodb = boto3.resource('dynamodb')
+cognito = boto3.client('cognito-idp')
+table = dynamodb.Table(os.environ['TABLE_NAME'])
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def handler(event: APIGatewayProxyEvent, context):
+    try:
+        order_id = event.path_parameters['orderId']
+        token = event.headers.get('Authorization')
+
+        # Decode token to get user information
+        user_info = cognito.get_user(AccessToken=token)
+        user_sub = next(attr['Value'] for attr in user_info['UserAttributes'] if attr['Name'] == 'sub')
+
+        response = table.get_item(Key={'orderId': order_id})
+        item = response.get('Item')
+
+        if not item:
+            return Response(
+                status_code=400,
+                body=json.dumps({"message": "Invalid order ID", "code": 400, "details": "Order ID provided is not valid."})
+            )
+
+        # Ensure the user has access to the order (either userId or hostId matches)
+        if item['userId'] != user_sub and item['hostId'] != user_sub:
+            return Response(
+                status_code=403,
+                body=json.dumps({"message": "User is not authorized to cancel this order"})
+            )
+
+        # Cancel the order by updating its status
+        table.update_item(
+            Key={'orderId': order_id},
+            UpdateExpression="set #status = :status",
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues={":status": "Cancelled"}
+        )
+
+        return Response(
+            status_code=200,
+            body=json.dumps({"message": "Order cancelled successfully"})
+        )
+
+    except cognito.exceptions.NotAuthorizedException as e:
+        logger.error(e)
+        return Response(
+            status_code=401,
+            body=json.dumps({"message": "Unauthorized"})
+        )
+    except Exception as e:
+        logger.error(e)
+        return Response(
+            status_code=500,
+            body=json.dumps({"message": "Internal server error", "error": str(e)})
+        )

--- a/orders/template.yaml
+++ b/orders/template.yaml
@@ -196,3 +196,36 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/lambda/${UpdateOrderFunction}"
       RetentionInDays: !Ref RetentionInDays
+
+  CancelOrderFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/orders/cancel_order/
+      Handler: main.handler
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:UpdateItem
+                - dynamodb:GetItem
+              Resource: !GetAtt OrdersTable.Arn
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - cognito-idp:AdminGetUser
+              Resource: "*"
+      Events:
+        CancelOrderApi:
+          Type: Api
+          Properties:
+            Path: /orders/cancel/{orderId}
+            Method: put
+            RestApiId: !Ref ApiGateway
+
+  CancelOrderFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${CancelOrderFunction}"
+      RetentionInDays: !Ref RetentionInDays


### PR DESCRIPTION
- Implemented a new PUT API endpoint `/orders/cancel/{orderId}` to cancel an order by order ID.
- Defined input validation and error handling to ensure only authorized users (order owner or host) can cancel the order.